### PR TITLE
Use "CharStreams" instead of "ANTLRInputStream"

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -48,3 +48,4 @@ CONTRIBUTORS:
 
 YYYY/MM/DD, github id, Full name, email
 2019/04/16, mike-lischke, Mike Lischke, mike@lischke-online.de
+2019/04/20, WopsS, Octavian Dima, Wo**S@users.noreply.github.com

--- a/src/backend/GrammarDebugger.ts
+++ b/src/backend/GrammarDebugger.ts
@@ -8,7 +8,7 @@
 import { EventEmitter } from "events";
 
 import {
-    ANTLRInputStream, CommonTokenStream, CommonToken, ParserRuleContext, Token, Lexer, Parser
+    CharStreams, CommonTokenStream, CommonToken, ParserRuleContext, Token, Lexer, Parser
 } from "antlr4ts";
 import { ParseTree, ErrorNode, TerminalNode } from "antlr4ts/tree";
 import { ScopedSymbol, VariableSymbol } from "antlr4-c3";
@@ -87,7 +87,7 @@ export class GrammarDebugger extends EventEmitter {
             };
 
             if (this.lexerData) {
-                let stream = new ANTLRInputStream("");
+                let stream = CharStreams.fromString("");
                 this.lexer = new GrammarLexerInterpreter(this.predicateEvaluator, this.contexts[0], lexerName, this.lexerData, stream);
                 this.lexer.removeErrorListeners();
                 this.lexer.addErrorListener(new InterpreterLexerErrorListener(eventSink));
@@ -108,7 +108,7 @@ export class GrammarDebugger extends EventEmitter {
     }
 
     public async start(startRuleIndex: number, input: string, noDebug: boolean) {
-        let stream = new ANTLRInputStream(input);
+        let stream = CharStreams.fromString(input);
         this.lexer.inputStream = stream;
 
         if (!this.parser) {

--- a/src/backend/SourceContext.ts
+++ b/src/backend/SourceContext.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 import {
-    ANTLRInputStream, CommonTokenStream, BailErrorStrategy, DefaultErrorStrategy, Token,  RuleContext, ParserRuleContext, Vocabulary
+    CharStreams, CommonTokenStream, BailErrorStrategy, DefaultErrorStrategy, Token,  RuleContext, ParserRuleContext, Vocabulary
 } from 'antlr4ts';
 import {
     PredictionMode, ATNState, RuleTransition, TransitionType, ATNStateType, RuleStartState
@@ -431,7 +431,7 @@ export class SourceContext {
      * This call doesn't do any expensive processing (parse() does).
      */
     public setText(source: string) {
-        let input = new ANTLRInputStream(source);
+        let input = CharStreams.fromString(source);
         let lexer = new ANTLRv4Lexer(input);
 
         // There won't be lexer errors actually. They are silently bubbled up and will cause parser errors.
@@ -920,7 +920,7 @@ export class SourceContext {
                 }
             }
 
-            let stream = new ANTLRInputStream(input);
+            let stream = CharStreams.fromString(input);
             let lexer = new GrammarLexerInterpreter(predicateEvaluator, this, "<unnamed>", this.grammarLexerData, stream);
             lexer.removeErrorListeners();
 
@@ -965,7 +965,7 @@ export class SourceContext {
             errors.push(args[0]);
         };
 
-        let stream = new ANTLRInputStream(input);
+        let stream = CharStreams.fromString(input);
         let lexer = new GrammarLexerInterpreter(predicateEvaluator, this, "<unnamed>", this.grammarLexerData, stream);
         lexer.removeErrorListeners();
 


### PR DESCRIPTION
"ANTLRInputStream" is deprecated in 4.7 and it doesn't support Unicode literals.

See https://github.com/antlr/antlr4/blob/master/doc/unicode.md.