### PR TITLE
Update instructions for debugging

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -50,3 +50,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/04/16, mike-lischke, Mike Lischke, mike@lischke-online.de
 2019/04/20, WopsS, Octavian Dima, Wo**S@users.noreply.github.com
 2019/10/26, mrd1996, Miguel Dias, mrd1996@hotmail.com
+2020/10/19, serras, Alejandro Serrano Mena, trupill@gmail.com


### PR DESCRIPTION
First of all, thanks for this awesome extension. This is making my job much easier and pleasant :)

The instructions in the `docs` folder for debugging are no longer up-to-date (I guess due to a change in Node.js, VSCode, or the extension itself). After digging, I found a way to make it work. This PR just updates the docs with the new knowledge I've gained.

Fixes #117