### PR TITLE
Custom css for each production in railroad diagrams

### DIFF
--- a/src/frontend/RailroadDiagramProvider.ts
+++ b/src/frontend/RailroadDiagramProvider.ts
@@ -60,7 +60,7 @@ export class AntlrRailroadDiagramProvider extends WebviewProvider {
                     || symbol.kind === SymbolKind.ParserRule
                     || symbol.kind === SymbolKind.FragmentLexerToken) {
                     const script = this.backend.getRRDScript(fileName, symbol.name);
-                    diagram += `<h3>${symbol.name}</h3>\n<script>${script}</script>\n\n`;
+                    diagram += `<h3 class=\"${symbol.name}-class\">${symbol.name}</h3>\n<script>${script}</script>\n\n`;
                 }
             }
             diagram += "</div>";


### PR DESCRIPTION
Hi, this trivial pull request made our live a bit easier. We have some elements that we don't want to see, and can now easily inject custom CSS to hide elements w̭̳̕i̧̭̮t̵̫̟̭̭͇̯ͅh̼̼̜̣̯o͉͟u̢ṱ͞ ͙̟̞̦ṕ̼̟̼a̻͉r̹͔͞ͅs̸͕̺ì͈̙̫͍͕̦ͅn̼̠g̤ ͇̝H͉̻̮̞͍͇̫T̨̹̺͕̝̩̙̫Ṃ̘͕̮̤̦L or using an XSLT-processor.

For example, we want to hide some a production LETTER, then in our custom css we perform

```
.LETTER-class {
                display: none;
        }
 h3.LETTER-class + svg {
                display: none;
        }

```