### PR TITLE
Add ANTLR4 syntax injection to markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "vscode-antlr4",
-    "version": "2.2.4",
+    "version": "2.2.4-markdown",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "2.2.4",
+            "name": "vscode-antlr4",
+            "version": "2.2.4-markdown",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "antlr4-c3": "^1.1.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-antlr4",
-    "version": "2.2.4-markdown",
+    "version": "2.2.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-antlr4",
-            "version": "2.2.4-markdown",
+            "version": "2.2.4",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "antlr4-c3": "^1.1.16",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "homepage": "http://www.soft-gems.net",
     "engines": {
-        "vscode": "^1.55.0"
+        "vscode": "^1.46.0"
     },
     "categories": [
         "Programming Languages",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,17 @@
                 "language": "antlr",
                 "scopeName": "source.antlr",
                 "path": "./syntaxes/antlr.json"
+            },
+            {
+                "language": "antlr-injection",
+                "scopeName": "markdown.antlr.codeblock",
+                "path": "./syntaxes/antlr.codeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.antlr": "antlr"
+                }
             }
         ],
         "themes": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "color": "#2789e1",
         "theme": "dark"
     },
-    "version": "2.2.4",
+    "version": "2.2.4-markdown",
     "publisher": "mike-lischke",
     "license": "SEE LICENSE IN LICENSE.txt",
     "repository": {
@@ -19,7 +19,7 @@
     },
     "homepage": "http://www.soft-gems.net",
     "engines": {
-        "vscode": "^1.46.0"
+        "vscode": "^1.55.0"
     },
     "categories": [
         "Programming Languages",
@@ -43,6 +43,9 @@
                 ],
                 "firstLine": "^(lexer|parser)?\\s*grammar\\s*\\w+\\s*;",
                 "configuration": "./antlr.configuration.json"
+            },
+            {
+                "id": "antlr-injection"
             }
         ],
         "grammars": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "color": "#2789e1",
         "theme": "dark"
     },
-    "version": "2.2.4-markdown",
+    "version": "2.2.4",
     "publisher": "mike-lischke",
     "license": "SEE LICENSE IN LICENSE.txt",
     "repository": {

--- a/syntaxes/antlr.codeblock.json
+++ b/syntaxes/antlr.codeblock.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"repository": {
-		"jacy-code-block": {
+		"antlr-code-block": {
 			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(antlr4|antlr|g4|g)(\\s+[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
@@ -31,7 +31,7 @@
 				{
 					"begin": "(^|\\G)(\\s*)(.*)",
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-					"contentName": "meta.embedded.block.antlr4",
+					"contentName": "meta.embedded.block.antlr",
 					"patterns": [
 						{
 							"include": "source.antlr"

--- a/syntaxes/antlr.codeblock.json
+++ b/syntaxes/antlr.codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#antlr-code-block"
+		}
+	],
+	"repository": {
+		"jacy-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(antlr4|antlr|g4|g)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.antlr4",
+					"patterns": [
+						{
+							"include": "source.antlr"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.antlr.codeblock"
+}


### PR DESCRIPTION
This pull request adds support for ANTLR4 syntax in markdown fenced code blocks.
It is implemented using injection grammars, you can read more about it [in official VSCode docs](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#injection-grammars).