### PR TITLE
Add some error handling to ExtensionHost

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -54,3 +54,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/03/31, oab, Ole Jørgen Abusdal, ole.jorgen.abusdal@gmail.com
 2021/10/02, hazmat345, Matt Patrick, ha**@gmail.com
 2022/02/15, hazer-hazer, Ivan Gordeev, gordeev.john@gmail.com
+2022/05/20, JoinedSenses, Arron Vinyard, jo**es@gmail.com

--- a/src/ExtensionHost.ts
+++ b/src/ExtensionHost.ts
@@ -119,8 +119,14 @@ export class ExtensionHost {
         for (const document of workspace.textDocuments) {
             if (FrontendUtils.isGrammarFile(document)) {
                 const antlrPath = path.join(path.dirname(document.fileName), ".antlr");
-                void this.backend.generate(document.fileName, { outputDir: antlrPath, loadOnly: true });
-                ATNGraphProvider.addStatesForGrammar(antlrPath, document.fileName);
+                try {
+                    void this.backend.generate(document.fileName, { outputDir: antlrPath, loadOnly: true });
+                    ATNGraphProvider.addStatesForGrammar(antlrPath, document.fileName);
+                }
+                catch (error) {
+                    this.outputChannel.appendLine((error as string) + ` (${document.fileName})`);
+                    this.outputChannel.show(true);
+                }
             }
         }
     }


### PR DESCRIPTION
As PR title suggests, this PR:
- Adds some error handling to ExtensionHost
    - Generation can fail for various reasons, such as serialized versions not matching.
    - Without try/catch, generation exceptions can cause the extension to not load.