### PR TITLE
Expose ExtensionHost.outputChannel for errors and wrap SourceContext parsing with try/catch

### DIFF
--- a/src/ExtensionHost.ts
+++ b/src/ExtensionHost.ts
@@ -57,7 +57,7 @@ export class ExtensionHost {
     private readonly importDir: string | undefined;
     private readonly backend: AntlrFacade;
     private readonly progress = new ProgressIndicator();
-    private readonly outputChannel = window.createOutputChannel("ANTLR4 Errors");
+    public static readonly outputChannel = window.createOutputChannel("ANTLR4 Errors");
 
     private readonly diagnosticCollection = languages.createDiagnosticCollection("antlr");
 
@@ -124,8 +124,8 @@ export class ExtensionHost {
                     ATNGraphProvider.addStatesForGrammar(antlrPath, document.fileName);
                 }
                 catch (error) {
-                    this.outputChannel.appendLine((error as string) + ` (${document.fileName})`);
-                    this.outputChannel.show(true);
+                    ExtensionHost.outputChannel.appendLine((error as string) + ` (${document.fileName})`);
+                    ExtensionHost.outputChannel.show(true);
                 }
             }
         }
@@ -206,9 +206,9 @@ export class ExtensionHost {
                     try {
                         config = JSON.parse(content) as ISentenceGenerationOptions;
                     } catch (reason) {
-                        this.outputChannel.appendLine("Cannot parse sentence generation config file:");
-                        this.outputChannel.appendLine((reason as SyntaxError).message);
-                        this.outputChannel.show(true);
+                        ExtensionHost.outputChannel.appendLine("Cannot parse sentence generation config file:");
+                        ExtensionHost.outputChannel.appendLine((reason as SyntaxError).message);
+                        ExtensionHost.outputChannel.show(true);
 
                         return;
                     }
@@ -224,8 +224,8 @@ export class ExtensionHost {
                 const [ruleName] = this.backend.ruleFromPosition(grammarFileName, caret.character, caret.line + 1);
 
                 if (!ruleName) {
-                    this.outputChannel.appendLine("ANTLR4 sentence generation: no rule selected");
-                    this.outputChannel.show(true);
+                    ExtensionHost.outputChannel.appendLine("ANTLR4 sentence generation: no rule selected");
+                    ExtensionHost.outputChannel.show(true);
 
                     return;
                 }
@@ -426,8 +426,8 @@ export class ExtensionHost {
                     }
                 } catch (reason) {
                     this.progress.stopAnimation();
-                    this.outputChannel.appendLine(reason as string);
-                    this.outputChannel.show(true);
+                    ExtensionHost.outputChannel.appendLine(reason as string);
+                    ExtensionHost.outputChannel.show(true);
                 }
             }
 
@@ -440,14 +440,14 @@ export class ExtensionHost {
                 this.progress.stopAnimation();
             }).catch((reason) => {
                 this.progress.stopAnimation();
-                this.outputChannel.appendLine(reason as string);
-                this.outputChannel.show(true);
+                ExtensionHost.outputChannel.appendLine(reason as string);
+                ExtensionHost.outputChannel.show(true);
             });
 
         }).catch((reason) => {
             this.progress.stopAnimation();
-            this.outputChannel.appendLine(reason as string);
-            this.outputChannel.show(true);
+            ExtensionHost.outputChannel.appendLine(reason as string);
+            ExtensionHost.outputChannel.show(true);
         });
     }
 

--- a/src/backend/SourceContext.ts
+++ b/src/backend/SourceContext.ts
@@ -61,6 +61,7 @@ import {
 } from "./GrammarInterpreters";
 import { printableUnicodePoints } from "./Unicode";
 import { BackendUtils } from "./BackendUtils";
+import { ExtensionHost } from "../ExtensionHost";
 
 import { IATNGraphData, IATNLink, IATNNode } from "../webview-scripts/types";
 
@@ -1597,24 +1598,34 @@ export class SourceContext {
         }
 
         if (fs.existsSync(lexerFile)) {
-            this.grammarLexerData = InterpreterDataReader.parseFile(lexerFile);
-            const map = new Map<string, number>();
-            for (let i = 0; i < this.grammarLexerData.ruleNames.length; ++i) {
-                map.set(this.grammarLexerData.ruleNames[i], i);
+            try {
+                this.grammarLexerData = InterpreterDataReader.parseFile(lexerFile);
+                const map = new Map<string, number>();
+                for (let i = 0; i < this.grammarLexerData.ruleNames.length; ++i) {
+                    map.set(this.grammarLexerData.ruleNames[i], i);
+                }
+                this.grammarLexerRuleMap = map;
+            } catch (error) {
+                ExtensionHost.outputChannel.appendLine((error as string) + ` (${lexerFile})`)
+                ExtensionHost.outputChannel.show(true)
             }
-            this.grammarLexerRuleMap = map;
         } else {
             this.grammarLexerData = undefined;
             this.grammarLexerRuleMap.clear();
         }
 
         if (fs.existsSync(parserFile)) {
-            this.grammarParserData = InterpreterDataReader.parseFile(parserFile);
-            const map = new Map<string, number>();
-            for (let i = 0; i < this.grammarParserData.ruleNames.length; ++i) {
-                map.set(this.grammarParserData.ruleNames[i], i);
+            try {
+                this.grammarParserData = InterpreterDataReader.parseFile(parserFile);
+                const map = new Map<string, number>();
+                for (let i = 0; i < this.grammarParserData.ruleNames.length; ++i) {
+                    map.set(this.grammarParserData.ruleNames[i], i);
+                }
+                this.grammarParserRuleMap = map;
+            } catch (error) {
+                ExtensionHost.outputChannel.appendLine((error as string) + ` (${parserFile})`)
+                ExtensionHost.outputChannel.show(true)
             }
-            this.grammarParserRuleMap = map;
         } else {
             this.grammarParserData = undefined;
             this.grammarParserRuleMap.clear();


### PR DESCRIPTION
Extends error handling from PR https://github.com/mike-lischke/vscode-antlr4/pull/173
- Expose ExtensionHost.outputChannel as static
- Add error handling for fiile parsing within backend\SourceContext