### PR TITLE
docs: Fixing JS function syntax in documentation

### DIFF
--- a/doc/grammar-debugging.md
+++ b/doc/grammar-debugging.md
@@ -38,11 +38,10 @@ Executing this code alone makes not much sense, usually. It often requires the i
 For example:
 
 ```Javascript
-"use strict"
+"use strict";
 
-  const version = 2;
-  doesItBlend() { return true; }
-}
+const version = 2;
+const doesItBlend = () => true;
 ```
 
 Errors during execution are reported back to get a chance of fixing any problem. With that action JS file in place you can then use semantic predicates as shown in this animation:


### PR DESCRIPTION
Updating grammar-debugging.md with right function syntax preventing docs misunderstanding.

Before:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/103655828/189485394-c19d3199-6a13-422a-afad-73e281151989.png">

After:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/103655828/189485427-787b1620-98fc-49a3-87a6-06210be66b56.png">

