### PR TITLE
Randomly choose an array element from rule mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ out
 node_modules
 generated
 coverage
+vscode-antlr4-*.vsix
+.antlr

--- a/contributors.txt
+++ b/contributors.txt
@@ -55,3 +55,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/10/02, hazmat345, Matt Patrick, ha**@gmail.com
 2022/02/15, hazer-hazer, Ivan Gordeev, gordeev.john@gmail.com
 2022/05/20, JoinedSenses, Arron Vinyard, jo**es@gmail.com
+2022/09/20, arlm, Alexandre Marcondes, ale**es@gmail.com

--- a/doc/sentence-generation.md
+++ b/doc/sentence-generation.md
@@ -40,7 +40,7 @@ To configure sentence generation for a grammar, create a file with the name of t
 - **minLexerIterations** (number, default: 0): The minimum number of iterations in the lexer (default: 1 for `+`, 0 for `*`). Must be a positive integer (or 0) and must be smaller than `maxLexerIterations` (if that is given). If set to 0 then for `+` loops 1 is used, automatically.
 - **maxLexerIterations** (number, default: minLexerIterations + 10): The maximum number of iterations in the lexer. Must be a number > 0 and > than `minLexerIterations`. If that is not the case or the value is not specified then it is set to `minLexerIterations` + 10.
 - **maxRecursions** (number, default: 3): The maximum number of recursions (rules calling themselves directly or indirectly).
-- **ruleMappings** (object, default: none): A mapping of rule names to string literals, which should be used instead of running the generation for that rule. For more details see below.
+- **ruleMappings** (object, default: none): A mapping of rule names to string literals or array of strings, which should be used instead of running the generation for that rule. For more details see below.
 - **actionFile** (string, default: none): The name of a file which contains code to evaluate grammar actions and predicates.
 
 ### Loops
@@ -62,6 +62,17 @@ The rule mappings object provides a way to explicitly specify the value for lexe
 {
     "ruleMapping": {
         "SingleQuotedString": "'Lorem Ipsum'",
+    }
+}
+```
+
+There is also the possibility of using an array of strings as a mapping value. On this case, one of the items will be chosen randomly. This is useful to create a greater variety of tokens for more realistic sentences. As it is all random, these is no way to coordinate how the mappings are chosen. Note that an empty array will be treated as if no mapping was found, and an array with only one item is the same as having the mapping to a simple string. This could be a mapping for a calculator lexer:
+
+```json
+{
+    "ruleMapping": {
+        "OPERATION": ["+", "-", "*", "/"],
+	"OPERAND": ["0", "12", "3", "42", "1.456"],
     }
 }
 ```

--- a/src/backend/SentenceGenerator.ts
+++ b/src/backend/SentenceGenerator.ts
@@ -249,12 +249,23 @@ export class SentenceGenerator {
                 return ["", false];
             }
 
-            const mapping = this.ruleMappings?.[ruleName];
-            if (mapping) {
+            const mappingValue = this.ruleMappings?.[ruleName];
+            if (mappingValue) {
+                let mapping: string | undefined;
                 if (Array.isArray(mapping)) {
-                    const randomElement = mapping[Math.floor(Math.random() * mapping.length)];
-                    return [addSpace ? randomElement + " " : randomElement, false];
+                    if (mapping.length < 0) {
+                        const randomIndex = Math.floor(Math.random() * mapping.length);
+                        const randomElement = mapping[randomIndex];
+
+                        mapping = randomElement;
+                    } else if (mapping.length === 1) {
+                        mapping = mapping[0];
+                    }
                 } else {
+                    mapping = mappingValue as string;
+                }
+
+                if (mapping) {
                     return [addSpace ? mapping + " " : mapping, false];
                 }
             }
@@ -366,7 +377,20 @@ export class SentenceGenerator {
                                         // its name for the output.
                                         const tokenName = this.lexerData.vocabulary.getSymbolicName(token);
                                         if (tokenName) {
-                                            const mapping = this.ruleMappings?.[tokenName];
+                                            const mappingValue = this.ruleMappings?.[tokenName];
+                                            let mapping: string | undefined;
+
+                                            if (Array.isArray(mappingValue)) {
+                                                if (mappingValue.length < 0) {
+                                                    const randomIndex = Math.floor(Math.random() * mappingValue.length);
+                                                    mapping = mappingValue[randomIndex];
+                                                } else if (mappingValue.length === 1) {
+                                                    mapping = mappingValue[0];
+                                                }
+                                            } else if (mappingValue) {
+                                                mapping = mappingValue;
+                                            }
+
                                             if (mapping) {
                                                 result += addSpace ? mapping + " " : mapping;
                                             } else {

--- a/src/backend/SentenceGenerator.ts
+++ b/src/backend/SentenceGenerator.ts
@@ -251,7 +251,12 @@ export class SentenceGenerator {
 
             const mapping = this.ruleMappings?.[ruleName];
             if (mapping) {
-                return [addSpace ? mapping + " " : mapping, false];
+                if (Array.isArray(mapping)) {
+                    const randomElement = mapping[Math.floor(Math.random() * mapping.length)];
+                    return [addSpace ? randomElement + " " : randomElement, false];
+                } else {
+                    return [addSpace ? mapping + " " : mapping, false];
+                }
             }
 
             if (!this.invokeRule(ruleName)) {

--- a/src/backend/SentenceGenerator.ts
+++ b/src/backend/SentenceGenerator.ts
@@ -252,15 +252,16 @@ export class SentenceGenerator {
             const mappingValue = this.ruleMappings?.[ruleName];
             if (mappingValue) {
                 let mapping: string | undefined;
-                if (Array.isArray(mapping)) {
-                    if (mapping.length < 0) {
-                        const randomIndex = Math.floor(Math.random() * mapping.length);
-                        const randomElement = mapping[randomIndex];
+
+                if (Array.isArray(mappingValue)) {
+                    if (mappingValue.length === 1) {
+                        mapping = mappingValue[0];
+                    } else if (mappingValue.length > 0) {
+                        const randomIndex = Math.floor(Math.random() * mappingValue.length);
+                        const randomElement = mappingValue[randomIndex];
 
                         mapping = randomElement;
-                    } else if (mapping.length === 1) {
-                        mapping = mapping[0];
-                    }
+                    } 
                 } else {
                     mapping = mappingValue as string;
                 }
@@ -379,16 +380,18 @@ export class SentenceGenerator {
                                         if (tokenName) {
                                             const mappingValue = this.ruleMappings?.[tokenName];
                                             let mapping: string | undefined;
-
-                                            if (Array.isArray(mappingValue)) {
-                                                if (mappingValue.length < 0) {
-                                                    const randomIndex = Math.floor(Math.random() * mappingValue.length);
-                                                    mapping = mappingValue[randomIndex];
-                                                } else if (mappingValue.length === 1) {
-                                                    mapping = mappingValue[0];
+                                            
+                                            if (mappingValue) {
+                                                if (Array.isArray(mappingValue)) {
+                                                    if (mappingValue.length === 1) {
+                                                        mapping = mappingValue[0];
+                                                    } else if (mappingValue.length > 0) {
+                                                        const randomIndex = Math.floor(Math.random() * mappingValue.length);
+                                                        mapping = mappingValue[randomIndex];
+                                                    }
+                                                } else if (mappingValue) {
+                                                    mapping = mappingValue;
                                                 }
-                                            } else if (mappingValue) {
-                                                mapping = mappingValue;
                                             }
 
                                             if (mapping) {

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -265,7 +265,7 @@ export interface ISentenceGenerationOptions {
  * Mappings from rule names to strings, which define output to use for specific rules when generating sentences.
  */
 export interface IRuleMappings {
-    [key: string]: string;
+    [key: string]: string | string[];
 }
 
 /**

--- a/test/backend/backend.spec.ts
+++ b/test/backend/backend.spec.ts
@@ -766,7 +766,7 @@ describe("vscode-antlr4 Backend Tests:", () => {
             }
         });
 
-        it("Generation with definitions", () => {
+        it("Generation with definitions with simple strings", () => {
             const ruleMappings: IRuleMappings = {
                 /* eslint-disable @typescript-eslint/naming-convention */
                 DIGITS: "12345",
@@ -806,12 +806,187 @@ describe("vscode-antlr4 Backend Tests:", () => {
             }
         });
 
+        it("Generation with definitions with single value arrays", () => {
+            const ruleMappings: IRuleMappings = {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DIGITS: ["12345"],
+                SimpleIdentifier: ["Mike"],
+                UnicodeIdentifier: ["µπåƒ"],
+                /* eslint-enable @typescript-eslint/naming-convention */
+            };
+
+            const tester = (rule: string, sentence: string) => {
+                //console.log(rule + ": " + sentence);
+                const errors = backend.parseTestInput("test/backend/sentences.g4", sentence, rule);
+                expect(errors).toHaveLength(0);
+
+                // In addition to error free generation check also that only known elements are in the sentence.
+                sentence = sentence.replace(/12345/g, "");
+                sentence = sentence.replace(/DEADBEEF/g, "");
+                sentence = sentence.replace(/Mike/g, "");
+                sentence = sentence.replace(/µπåƒ/g, "");
+                sentence = sentence.replace(/red/g, "");
+                sentence = sentence.replace(/green/g, "");
+                sentence = sentence.replace(/blue/g, "");
+                sentence = sentence.replace(/[0-9{},.:]/g, "");
+                sentence = sentence.trim();
+                //console.log(rule + ": " + sentence);
+                expect(sentence).toHaveLength(0);
+            };
+
+            const rules = backend.getRuleList("test/backend/sentences.g4")!;
+            for (const rule of rules) {
+                backend.generateSentence("test/backend/sentences.g4", rule, {
+                    count: 10,
+                    maxLexerIterations: 7,
+                    maxParserIterations: 7,
+                    ruleMappings,
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                }, tester.bind(this, rule));
+            }
+        });
+
+        it("Generation with definitions with emtpy arrays", () => {
+            const ruleMappings: IRuleMappings = {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DIGITS: [],
+                SimpleIdentifier: [],
+                UnicodeIdentifier: [],
+                /* eslint-enable @typescript-eslint/naming-convention */
+            };
+
+            const tester = (rule: string, sentence: string) => {
+                //console.log(rule + ": " + sentence);
+                const errors = backend.parseTestInput("test/backend/sentences.g4", sentence, rule);
+                expect(errors).toHaveLength(0);
+
+                // In addition to error free generation check also that only known elements are in the sentence.
+                sentence = sentence.replace(/12345/g, "");
+                sentence = sentence.replace(/DEADBEEF/g, "");
+                sentence = sentence.replace(/Mike/g, "");
+                sentence = sentence.replace(/µπåƒ/g, "");
+                sentence = sentence.replace(/red/g, "");
+                sentence = sentence.replace(/green/g, "");
+                sentence = sentence.replace(/blue/g, "");
+                sentence = sentence.replace(/[0-9{},.:]/g, "");
+                sentence = sentence.trim();
+                //console.log(rule + ": " + sentence);
+            };
+
+            const rules = backend.getRuleList("test/backend/sentences.g4")!;
+            for (const rule of rules) {
+                backend.generateSentence("test/backend/sentences.g4", rule, {
+                    count: 10,
+                    maxLexerIterations: 7,
+                    maxParserIterations: 7,
+                    ruleMappings,
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                }, tester.bind(this, rule));
+            }
+        });
+
+        it("Generation with definitions with arrays", () => {
+            const ruleMappings: IRuleMappings = {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DIGITS: ["12345", "54321"],
+                SimpleIdentifier: ["Mike", "John", "Mary"],
+                UnicodeIdentifier: ["µπåƒ", "você", "𓂷", "ꫪ𝚫", "𠦄𣛯𪃾", "പửၒ", "ᚱꙍ𒅍"],
+                /* eslint-enable @typescript-eslint/naming-convention */
+            };
+
+            const tester = (rule: string, sentence: string) => {
+                //console.log(rule + ": " + sentence);
+                const errors = backend.parseTestInput("test/backend/sentences.g4", sentence, rule);
+                expect(errors).toHaveLength(0);
+
+                // In addition to error free generation check also that only known elements are in the sentence.
+                sentence = sentence.replace(/12345/g, "");
+                sentence = sentence.replace(/54321/g, "");
+                sentence = sentence.replace(/DEADBEEF/g, "");
+                sentence = sentence.replace(/Mike/g, "");
+                sentence = sentence.replace(/John/g, "");
+                sentence = sentence.replace(/Mary/g, "");
+                sentence = sentence.replace(/µπåƒ/g, "");
+                sentence = sentence.replace(/você/g, "");
+                sentence = sentence.replace(/𓂷/g, "");
+                sentence = sentence.replace(/ꫪ𝚫/g, "");
+                sentence = sentence.replace(/𠦄𣛯𪃾/g, "");
+                sentence = sentence.replace(/പửၒ/g, "");
+                sentence = sentence.replace(/ᚱꙍ𒅍/g, "");
+                sentence = sentence.replace(/red/g, "");
+                sentence = sentence.replace(/green/g, "");
+                sentence = sentence.replace(/blue/g, "");
+                sentence = sentence.replace(/[0-9{},.:]/g, "");
+                sentence = sentence.trim();
+                //console.log(rule + ": " + sentence);
+                expect(sentence).toHaveLength(0);
+            };
+
+            const rules = backend.getRuleList("test/backend/sentences.g4")!;
+            for (const rule of rules) {
+                backend.generateSentence("test/backend/sentences.g4", rule, {
+                    count: 10,
+                    maxLexerIterations: 7,
+                    maxParserIterations: 7,
+                    ruleMappings,
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                }, tester.bind(this, rule));
+            }
+        });
+
+        it("Generation with mixed definition values", () => {
+            const ruleMappings: IRuleMappings = {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DIGITS: "12345",
+                SimpleIdentifier: ["Mike"],
+                UnicodeIdentifier: ["µπåƒ", "você", "𓂷", "ꫪ𝚫", "𠦄𣛯𪃾", "പửၒ", "ᚱꙍ𒅍"],
+                /* eslint-enable @typescript-eslint/naming-convention */
+            };
+
+            const tester = (rule: string, sentence: string) => {
+                //console.log(rule + ": " + sentence);
+                const errors = backend.parseTestInput("test/backend/sentences.g4", sentence, rule);
+                expect(errors).toHaveLength(0);
+
+                // In addition to error free generation check also that only known elements are in the sentence.
+                sentence = sentence.replace(/12345/g, "");
+                sentence = sentence.replace(/DEADBEEF/g, "");
+                sentence = sentence.replace(/Mike/g, "");
+                sentence = sentence.replace(/µπåƒ/g, "");
+                sentence = sentence.replace(/você/g, "");
+                sentence = sentence.replace(/𓂷/g, "");
+                sentence = sentence.replace(/ꫪ𝚫/g, "");
+                sentence = sentence.replace(/𠦄𣛯𪃾/g, "");
+                sentence = sentence.replace(/പửၒ/g, "");
+                sentence = sentence.replace(/ᚱꙍ𒅍/g, "");
+                sentence = sentence.replace(/red/g, "");
+                sentence = sentence.replace(/green/g, "");
+                sentence = sentence.replace(/blue/g, "");
+                sentence = sentence.replace(/[0-9{},.:]/g, "");
+                sentence = sentence.trim();
+                //console.log(rule + ": " + sentence);
+                expect(sentence).toHaveLength(0);
+            };
+
+            const rules = backend.getRuleList("test/backend/sentences.g4")!;
+            for (const rule of rules) {
+                backend.generateSentence("test/backend/sentences.g4", rule, {
+                    count: 10,
+                    maxLexerIterations: 7,
+                    maxParserIterations: 7,
+                    ruleMappings,
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                }, tester.bind(this, rule));
+            }
+        });
+
         afterAll(() => {
             backend.releaseGrammar("test/backend/sentences.g4");
             backend.releaseGrammar("test/backend/CPP14.g4");
             fs.rmSync("generated", { recursive: true, force: true });
         });
     });
+    
 
     describe("Formatting:", () => {
         it("With all options (except alignment)", () => {

--- a/test/backend/backend.spec.ts
+++ b/test/backend/backend.spec.ts
@@ -890,7 +890,7 @@ describe("vscode-antlr4 Backend Tests:", () => {
                 /* eslint-disable @typescript-eslint/naming-convention */
                 DIGITS: ["12345", "54321"],
                 SimpleIdentifier: ["Mike", "John", "Mary"],
-                UnicodeIdentifier: ["µπåƒ", "você", "𓂷", "ꫪ𝚫", "𠦄𣛯𪃾", "പửၒ", "ᚱꙍ𒅍"],
+                UnicodeIdentifier: ["µπåƒ", "você", "𑃖𓂷", "𑃖ꫪ𝚫", "𑃖𠦄𣛯𪃾", "𑃖പửၒ", "𑃖ᚱꙍ𒅍"],
                 /* eslint-enable @typescript-eslint/naming-convention */
             };
 
@@ -908,11 +908,11 @@ describe("vscode-antlr4 Backend Tests:", () => {
                 sentence = sentence.replace(/Mary/g, "");
                 sentence = sentence.replace(/µπåƒ/g, "");
                 sentence = sentence.replace(/você/g, "");
-                sentence = sentence.replace(/𓂷/g, "");
-                sentence = sentence.replace(/ꫪ𝚫/g, "");
-                sentence = sentence.replace(/𠦄𣛯𪃾/g, "");
-                sentence = sentence.replace(/പửၒ/g, "");
-                sentence = sentence.replace(/ᚱꙍ𒅍/g, "");
+                sentence = sentence.replace(/𑃖𓂷/g, "");
+                sentence = sentence.replace(/𑃖ꫪ𝚫/g, "");
+                sentence = sentence.replace(/𑃖𠦄𣛯𪃾/g, "");
+                sentence = sentence.replace(/𑃖പửၒ/g, "");
+                sentence = sentence.replace(/𑃖ᚱꙍ𒅍/g, "");
                 sentence = sentence.replace(/red/g, "");
                 sentence = sentence.replace(/green/g, "");
                 sentence = sentence.replace(/blue/g, "");
@@ -939,7 +939,7 @@ describe("vscode-antlr4 Backend Tests:", () => {
                 /* eslint-disable @typescript-eslint/naming-convention */
                 DIGITS: "12345",
                 SimpleIdentifier: ["Mike"],
-                UnicodeIdentifier: ["µπåƒ", "você", "𓂷", "ꫪ𝚫", "𠦄𣛯𪃾", "പửၒ", "ᚱꙍ𒅍"],
+                UnicodeIdentifier: ["µπåƒ", "você", "𑃖𓂷", "𑃖ꫪ𝚫", "𑃖𠦄𣛯𪃾", "𑃖പửၒ", "𑃖ᚱꙍ𒅍"],
                 /* eslint-enable @typescript-eslint/naming-convention */
             };
 
@@ -950,20 +950,24 @@ describe("vscode-antlr4 Backend Tests:", () => {
 
                 // In addition to error free generation check also that only known elements are in the sentence.
                 sentence = sentence.replace(/12345/g, "");
+                sentence = sentence.replace(/54321/g, "");
                 sentence = sentence.replace(/DEADBEEF/g, "");
                 sentence = sentence.replace(/Mike/g, "");
+                sentence = sentence.replace(/John/g, "");
+                sentence = sentence.replace(/Mary/g, "");
                 sentence = sentence.replace(/µπåƒ/g, "");
                 sentence = sentence.replace(/você/g, "");
-                sentence = sentence.replace(/𓂷/g, "");
-                sentence = sentence.replace(/ꫪ𝚫/g, "");
-                sentence = sentence.replace(/𠦄𣛯𪃾/g, "");
-                sentence = sentence.replace(/പửၒ/g, "");
-                sentence = sentence.replace(/ᚱꙍ𒅍/g, "");
+                sentence = sentence.replace(/𑃖𓂷/g, "");
+                sentence = sentence.replace(/𑃖ꫪ𝚫/g, "");
+                sentence = sentence.replace(/𑃖𠦄𣛯𪃾/g, "");
+                sentence = sentence.replace(/𑃖പửၒ/g, "");
+                sentence = sentence.replace(/𑃖ᚱꙍ𒅍/g, "");
                 sentence = sentence.replace(/red/g, "");
                 sentence = sentence.replace(/green/g, "");
                 sentence = sentence.replace(/blue/g, "");
                 sentence = sentence.replace(/[0-9{},.:]/g, "");
                 sentence = sentence.trim();
+                sentence = sentence.trim();               
                 //console.log(rule + ": " + sentence);
                 expect(sentence).toHaveLength(0);
             };


### PR DESCRIPTION
This proposes a way to have multiple-choices on the mapped rules for generation of sentences. When the value of the rule on the JSON file is an array it will choose one of the values randomly.

That feature helps to create more realistic sentences and also to test-proof the grammar/lexer rules.