### PR TITLE
Fixed error file name parsing on windows

### DIFF
--- a/src/backend/ErrorParser.ts
+++ b/src/backend/ErrorParser.ts
@@ -20,7 +20,7 @@ import { SourceContext } from "./SourceContext";
  */
 
 export class ErrorParser {
-    private static errorPattern = /(\w+)\s*\((\d+)\):\s*([^:]*):(\d*):(\d*):\s*(.+)/;
+    private static errorPattern = /(\w+)\s*\((\d+)\):\s*((?:\w:)?[^:]*):(\d*):(\d*):\s*(.+)/;
     private static errorCodeToPattern: Map<number, RegExp> = new Map([
         [8, /grammar name (\w+)/],
         [56, /:\s+(\w+)/],


### PR DESCRIPTION
Currently the regex used for parsing errors does not work properly on windows. The group that looks for the file path: `([^:]*)` is wrong, since absolute paths do contain a `:` character after the drive letter.
```
warning(146): e:\Chug\Chug\Antlr\ChugLexer.g4:30:4: non-fragment lexer rule EXP_END can match the empty string
```
I've fixed this by including an optional non-capturing group for the drive letter: `((?:\w:)?[^:]*)` I have not tested the fix on a different OS, but I think it should be fine.

For me this was actually a fairly serious problem, since it caused the extension to treat the above warning as a fatal error. Since  I'm using a separate lexer and parser, this stopped the parser from being generated.