### PR TITLE
Add command category to all commands

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -56,3 +56,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/02/15, hazer-hazer, Ivan Gordeev, gordeev.john@gmail.com
 2022/05/20, JoinedSenses, Arron Vinyard, jo**es@gmail.com
 2022/09/20, arlm, Alexandre Marcondes, ale**es@gmail.com
+2023/08/28, Ghost4Man, Daniel Kosík, kosik.dan@gmail.com

--- a/package.json
+++ b/package.json
@@ -364,23 +364,28 @@
         "commands": [
             {
                 "command": "antlr.atn.singleRule",
-                "title": "Show ATN Graph for Rule"
+                "title": "Show ATN Graph for Rule",
+                "category": "ANTLR"
             },
             {
                 "command": "antlr.rrd.singleRule",
-                "title": "Show Railroad Diagram for Rule"
+                "title": "Show Railroad Diagram for Rule",
+                "category": "ANTLR"
             },
             {
                 "command": "antlr.rrd.allRules",
-                "title": "Show Railroad Diagram for All Rules"
+                "title": "Show Railroad Diagram for All Rules",
+                "category": "ANTLR"
             },
             {
                 "command": "antlr.call-graph",
-                "title": "Show Grammar Call Graph"
+                "title": "Show Grammar Call Graph",
+                "category": "ANTLR"
             },
             {
                 "command": "antlr.tools.generateSentences",
-                "title": "Generate Valid Input for Rule"
+                "title": "Generate Valid Input for Rule",
+                "category": "ANTLR"
             }
         ],
         "menus": {


### PR DESCRIPTION
This PR proposes adding [`category`](https://code.visualstudio.com/api/references/contribution-points#contributes.commands) "ANTLR" to all commands to ensure they are searchable/discoverable by typing "antlr" in the command palette.

Before:
![before - searching for "antlr" in command palette does not bring up commands from this extension](https://github.com/mike-lischke/vscode-antlr4/assets/8436102/07a96a2c-22d0-476c-9fe7-fc5884cb469b)

After:
![after - all commands are visible in the command palette when searching for "antlr"](https://github.com/mike-lischke/vscode-antlr4/assets/8436102/4e6b46ae-3f45-495f-967f-17668f221845)