### PR TITLE
Add a config variable to allow users to set the Java executable location (fixes issue #57)

### DIFF
--- a/doc/extension-settings.md
+++ b/doc/extension-settings.md
@@ -24,6 +24,7 @@ This is a settings object named **antlr4.generation** with the following members
 * **language**, string (default: "Java"), specifies the target language for the generated code, overriding what is specified in the grammar (used only in external mode)
 * **listeners**, boolean (default: true), also create listeners on code generation (used only in external mode)
 * **visitors**, boolean (default: false), also create visitors on code generation (used only in external mode)
+* **javaHomeOverride**, string (default: undefined), specifies an alternative `JAVA_HOME` if the environment variable is not set or a different Java installation should be used. If this variable is undefined and the process does not have the environment variable `JAVA_HOME` set then the extension will try to launch `java` in the current `PATH`.
 * **alternativeJar**, string (default: undefined), specifies the ANTLR4 jar to use for generation, instead of the ones shipping with this extension.
 * **additionalParameters**, string | string[] (default: undefined), specifies additional parameters to be passed on to the ANTLR4 jar (built-in or custom) during parser generation.
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,10 @@
                             "default": false,
                             "description": "Also create visitors on code generation"
                         },
+                        "javaHomeOverride": {
+                            "type": "string",
+                            "description": "Path to your JDK/JRE installation. Set this if `java` is not on your `$PATH` or you wish to use a different Java installation. The Java binary at `${javaHomeOverride}/bin/java` will be used to invoke antlr if this property is set."
+                        },
                         "alternativeJar": {
                             "type": "string",
                             "description": "Path to a Java jar file to be used for parser generation"

--- a/src/ExtensionHost.ts
+++ b/src/ExtensionHost.ts
@@ -401,6 +401,7 @@ export class ExtensionHost {
             outputDir,
             listeners: false,
             visitors: false,
+            javaHomeOverride: workspace.getConfiguration("antlr4.generation").get<string>("javaHomeOverride"),
             alternativeJar: workspace.getConfiguration("antlr4.generation").get<string>("alternativeJar"),
             additionalParameters: workspace.getConfiguration("antlr4.generation")
                 .get<string | string[]>("additionalParameters"),

--- a/src/backend/SourceContext.ts
+++ b/src/backend/SourceContext.ts
@@ -1114,7 +1114,7 @@ export class SourceContext {
             fileList.push(dependency.fileName);
 
             const actualParameters = [...parameters, dependency.fileName];
-            const result = await this.doGeneration(actualParameters, spawnOptions, errorParser, options.outputDir);
+            const result = await this.doGeneration(actualParameters, spawnOptions, errorParser, options.javaHomeOverride, options.outputDir);
             if (result.length > 0) {
                 message += "\n" + result;
             }
@@ -1701,16 +1701,21 @@ export class SourceContext {
      * @param parameters The command line parameters fro ANTLR4.
      * @param spawnOptions The options for spawning Java.
      * @param errorParser The parser to use for ANTLR4 error messages.
+     * @param javaHomeOverride The path to use for locating the Java binary.
      * @param outputDir The directory to find the interpreter data.
      *
      * @returns A string containing the error for non-grammar problems (process or java issues) otherwise empty.
      */
     private doGeneration(parameters: string[], spawnOptions: object, errorParser: ErrorParser,
-        outputDir?: string): Promise<string> {
+        javaHomeOverride?: string, outputDir?: string): Promise<string> {
         return new Promise((resolve, reject) => {
+            const javaHome = javaHomeOverride || process.env.JAVA_HOME;
+            const javaBinPath = javaHome ? path.join(javaHome, "bin", "java") : "java";
+
+            Log.debug(`Using Java binary at: ${javaBinPath}`);
             Log.debug(`Running Java with parameters: ${parameters.join(" ")}`);
 
-            const java = spawn("java", parameters, spawnOptions);
+            const java = spawn(javaBinPath, parameters, spawnOptions);
 
             java.on("error", (error) => {
                 resolve(`Error while running Java: "${error.message}". Is Java installed on you machine?`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,9 @@ export interface IGenerationOptions {
     /** Used with `loadOnly` to generate if no interpreter data exists yet. */
     generateIfNeeded?: boolean;
 
+    /** Use this path to find the Java binary instead of JAVA_HOME */
+    javaHomeOverride?: string;
+
     /** Use this jar for work instead of the built-in one(s). */
     alternativeJar?: string;
 


### PR DESCRIPTION
Fixes issue #57.

This adds a new configuration variable called `javaHomeOverride`. This allows users to explicitly set JAVA_HOME if it is not present or if they wish to use a different Java installation. The Java executable is looked up at `${javaHomeOverride}/bin/java` in this case.

This also changes the default behavior to use `$JAVA_HOME/bin/java` as the Java executable to be consistent.

If neither of `javaHomeOverride` or the JAVA_HOME environment variable are set then the extension attempts to launch `java` in PATH as before.

I'm happy to adjust this as needed, feedback welcome.