### PR TITLE
fix: correct map clearing logic

### DIFF
--- a/src/backend/SourceContext.ts
+++ b/src/backend/SourceContext.ts
@@ -764,7 +764,7 @@ export class SourceContext implements ISourceContext {
         this.grammarLexerData = undefined;
         this.grammarLexerRuleMap.clear();
         this.grammarParserData = undefined;
-        this.grammarLexerRuleMap.clear();
+        this.grammarParserRuleMap.clear();
 
         this.semanticAnalysisDone = false;
         this.diagnostics.length = 0;


### PR DESCRIPTION
Corrected an issue where lexerRuleMap.clear() was called twice instead of clearing both parserRuleMap and lexerRuleMap.